### PR TITLE
Fix swizzle generation

### DIFF
--- a/src/CSHLSL.CoreLib.CodeGen/SwizzleVectorFieldGenerator.cs
+++ b/src/CSHLSL.CoreLib.CodeGen/SwizzleVectorFieldGenerator.cs
@@ -48,7 +48,7 @@ public sealed class SwizzleVectorFieldGenerator : ISourceGenerator {
     private static void GenerateCombinations(char[] validChars, HashSet<string> combinations) {
         var validLength = validChars.Length;
 
-        for (var length = 1; length <= validLength; length++) {
+        for (var length = 1; length <= 4; length++) {
             var combo = new char[length];
             for (var i = 0; i < length; i++)
                 combo[i] = validChars[0];


### PR DESCRIPTION
Swizzle generation should generate up to float4 for every type, such as Vector1`1.XX, Vector1`1.XXX, Vector1`1.XXXX.